### PR TITLE
Adiciona configuração para personalização

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,3 @@
+@import "theme.css";
+
+.wy-menu-vertical header,.wy-menu-vertical p.caption{color:#b68df5;height:32px;line-height:32px;padding:0 1.618em;margin:12px 0 0;display:block;font-weight:700;text-transform:uppercase;font-size:85%;white-space:nowrap}

--- a/docs/en/source/conf.py
+++ b/docs/en/source/conf.py
@@ -63,6 +63,23 @@ html_theme_options = {
     'style_nav_header_background': "#5e3f8e",
 }
 
+# A list of paths that contain custom _static files (such as style sheets or 
+# script files). Relative paths are taken as relative to the configuration 
+# directory
+html_static_path = ['../../_static']
+
+# The style sheet to use for HTML pages. A file of that name must exist either 
+# in Sphinx’s _static/ path, or in one of the custom paths given in 
+# html_static_path. Default is the stylesheet given by the selected theme. If 
+# you only want to add or override a few things compared to the theme’s 
+# stylesheet, use CSS @import to import the theme’s stylesheet.
+html_style = 'css/custom.css'
+
+# A list of CSS files. The entry must be a filename string or a tuple containing
+# the filename string and the attributes dictionary.
+#
+html_css_files = ['custom.css']
+
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
 #
@@ -76,6 +93,4 @@ html_favicon = "../../_static/favicon.ico"
 
 # Language to be used for generating the HTML full-text search index.
 html_search_language = 'en'
-
-
 

--- a/docs/pt_BR/source/conf.py
+++ b/docs/pt_BR/source/conf.py
@@ -63,6 +63,23 @@ html_theme_options = {
     'style_nav_header_background': "#5e3f8e",
 }
 
+# A list of paths that contain custom _static files (such as style sheets or 
+# script files). Relative paths are taken as relative to the configuration 
+# directory
+html_static_path = ['../../_static']
+
+# The style sheet to use for HTML pages. A file of that name must exist either 
+# in Sphinx’s _static/ path, or in one of the custom paths given in 
+# html_static_path. Default is the stylesheet given by the selected theme. If 
+# you only want to add or override a few things compared to the theme’s 
+# stylesheet, use CSS @import to import the theme’s stylesheet.
+html_style = 'css/custom.css'
+
+# A list of CSS files. The entry must be a filename string or a tuple containing
+# the filename string and the attributes dictionary.
+#
+html_css_files = ['custom.css']
+
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
 #


### PR DESCRIPTION
Esta PR adiciona uma customização do tema "sphinx_rtd_theme", conforme orientado em: [Overriding or replacing a theme’s stylesheet](https://docs.readthedocs.io/en/stable/guides/adding-custom-css.html#overriding-or-replacing-a-theme-s-stylesheet). Não foi adotado a escolha por substituir o tema, apenas sobreescrever estilos desejados. Por isso, o arquivo de customização `custom.css` importa o tema original. 

Por enquanto, apenas a cor dos títulos no menu de navegação foi alterada, de azul para roxo. 
Para adicionar outras customizações, basta modificar o arquivo `custom.css`


### ANTES: Títulos no menu em azul
![image](https://github.com/okfn-brasil/querido-diario-comunidade/assets/44185775/9e5e3633-db38-47d5-9f6c-aa8ef93eff3e)

### DEPOIS: Títulos no menu em roxo
PR preview: https://querido-diario--90.org.readthedocs.build/pt-br/90/
![image](https://github.com/okfn-brasil/querido-diario-comunidade/assets/44185775/35f51860-c72a-4d51-9e7c-34490d3157c7)


