### PR TITLE
Tradução da página 'projetos-relacionados'.

### DIFF
--- a/docs/en/source/understanding/related-projects.rst
+++ b/docs/en/source/understanding/related-projects.rst
@@ -1,4 +1,53 @@
 Related Projects
 ###########################
 
-Soon
+With Querido Diário handling the heavy and innovative work of collecting, storing, and making thousands of municipal gazettes available, get to know projects that already use our data.
+
+`Querido Diário\: Technologies in Education`_
+************************************************
+
+`Querido Diário\: Technologies in Education`_ is capable of indentifying official acts related to the world of technologies acquired by the basic education network at the municipality level in specific themes such as accessibility, connectivity, management, infrastructure,  artificial inteligence, robotics, etc.
+
+.. image:: https://querido-diario-static.nyc3.cdn.digitaloceanspaces.com/docs/related-projects/querido-diario-tecnologias-educacao.png
+    :alt: "Querido Diário: Technology in education" Webpage
+    
+`Diário do Clima`_
+**********************************
+
+`Diário do clima`_ monitors gazettes to identify the most relevant documents on public policies related to climate and the enviroment. Users can track official action related to environmental crimes, biodiversity, mining, water, sanitation, etc. as soon as new official acts are published.
+
+.. image:: https://querido-diario-static.nyc3.cdn.digitaloceanspaces.com/docs/related-projects/diario-do-clima.png
+    :alt: "Diário do clima" webpage.
+ 
+ `LegislaTech`_
+ *****************
+ 
+ `LegislaTech`_ monitors public documents - specially legislative proceedings, judicial documents, gazettes, and even news- seeking topics of interest for users.
+ 
+ .. image:: https://querido-diario-static.nyc3.cdn.digitaloceanspaces.com/docs/related-projects/legislatech.png
+    :alt: LegislaTech webpage.
+    
+
+
+`Exoonero`_
+*******************
+
+`Exoonero`_ classifies,among appointments and dismissals, the official acts from the gazettes of the Association of Alagoan Municipalities, providing general and specific statistcs by municipality and by year.
+
+.. image:: https://querido-diario-static.nyc3.cdn.digitaloceanspaces.com/docs/related-projects/exoonero.png
+    :alt: Exoonero Webpage.
+
+ Ro-Dou
+ *************
+ 
+Ro-Dou is a tool of the Brazilian Ministry of Economy that supports the daily activities of various public agencies by generating email *clippings* for officials. Initially create to monitor the Official Gazette of the Union, it has also begun using municipal gazettes as a source.
+ 
+**Learn more**: `Ro-DOU Registration in the Ministry's Solutions Catalog`_.
+ 
+.. REFERÊNCIAS
+.. _Querido Diário\: Technologies in Education: https://queridodiario.ok.org.br/educacao
+.. _Diário do Clima: https://diariodoclima.org.br/
+.. _LegislaTech: https://legisla.tech/
+.. _Exoonero: https://exoonero.org/
+.. _Ro-DOU Registration in the Ministry's Solutions Catalog: https://www.gov.br/economia/pt-br/acesso-a-informacao/acoes-e-programas/transformagov/catalogodesolucoes/ro-dou
+

--- a/docs/en/source/understanding/related-projects.rst
+++ b/docs/en/source/understanding/related-projects.rst
@@ -17,14 +17,14 @@ With Querido Diário handling the heavy and innovative work of collecting, stori
 `Diário do clima`_ monitors gazettes to identify the most relevant documents on public policies related to climate and the enviroment. Users can track official action related to environmental crimes, biodiversity, mining, water, sanitation, etc. as soon as new official acts are published.
 
 .. image:: https://querido-diario-static.nyc3.cdn.digitaloceanspaces.com/docs/related-projects/diario-do-clima.png
-    :alt: "Diário do clima" webpage.
+   :alt: "Diário do clima" webpage.
  
- `LegislaTech`_
- *****************
+`LegislaTech`_
+*****************
  
- `LegislaTech`_ monitors public documents - specially legislative proceedings, judicial documents, gazettes, and even news- seeking topics of interest for users.
+`LegislaTech`_ monitors public documents - specially legislative proceedings, judicial documents, gazettes, and even news- seeking topics of interest for users.
  
- .. image:: https://querido-diario-static.nyc3.cdn.digitaloceanspaces.com/docs/related-projects/legislatech.png
+.. image:: https://querido-diario-static.nyc3.cdn.digitaloceanspaces.com/docs/related-projects/legislatech.png
     :alt: LegislaTech webpage.
     
 
@@ -32,13 +32,13 @@ With Querido Diário handling the heavy and innovative work of collecting, stori
 `Exoonero`_
 *******************
 
-`Exoonero`_ classifies,among appointments and dismissals, the official acts from the gazettes of the Association of Alagoan Municipalities, providing general and specific statistcs by municipality and by year.
+`Exoonero`_ classifies, among appointments and dismissals, the official acts from the gazettes of the Association of Alagoan Municipalities, providing general and specific statistcs by municipality and by year.
 
 .. image:: https://querido-diario-static.nyc3.cdn.digitaloceanspaces.com/docs/related-projects/exoonero.png
     :alt: Exoonero Webpage.
 
- Ro-Dou
- *************
+Ro-Dou
+*************
  
 Ro-Dou is a tool of the Brazilian Ministry of Economy that supports the daily activities of various public agencies by generating email *clippings* for officials. Initially create to monitor the Official Gazette of the Union, it has also begun using municipal gazettes as a source.
  

--- a/docs/pt_BR/source/entendendo/projetos-relacionados.rst
+++ b/docs/pt_BR/source/entendendo/projetos-relacionados.rst
@@ -14,7 +14,7 @@ a nível municipal em temáticas específicas como acessibilidade, conectividade
 gestão, infraestrutura, inteligência artificial, robótica, etc.
 
 .. image:: https://querido-diario-static.nyc3.cdn.digitaloceanspaces.com/docs/related-projects/querido-diario-tecnologias-educacao.png
-    :alt: [TODO]
+    :alt: Página do "Querido Diário: Tecnologias na Educação".
 
 
 `Diário do Clima`_
@@ -26,7 +26,7 @@ podem acompanhar movimentações oficiais relacionadas a crimes ambientais, biod
 mineração, água, saneamento, etc, assim que novos atos oficias forem publicados.
 
 .. image:: https://querido-diario-static.nyc3.cdn.digitaloceanspaces.com/docs/related-projects/diario-do-clima.png
-    :alt: [TODO]
+    :alt: Página do "Diário do clima".
 
 
 `LegislaTech`_
@@ -37,7 +37,7 @@ judiciais, diários oficiais e até notícias - em busca de assuntos de interess
 as pessoas usuárias.
 
 .. image:: https://querido-diario-static.nyc3.cdn.digitaloceanspaces.com/docs/related-projects/legislatech.png
-    :alt: [TODO]
+    :alt: Página do "LegislaTech".
 
 
 `Exoonero`_
@@ -48,7 +48,7 @@ diários da Associação de Municípios Alagoanos, oferecendo estatísticas gera
 específicas por município e por ano.
 
 .. image:: https://querido-diario-static.nyc3.cdn.digitaloceanspaces.com/docs/related-projects/exoonero.png
-    :alt: [TODO]
+    :alt: Página do "Exoonero".
 
 
 Ro-DOU


### PR DESCRIPTION
Part of #97 

- Tradução a página `entendendo/projetos-relacionados`  da documentação em `understanding/related-projects`
- Criação de textos alternativos para as imagens dos respectivos arquivos.

Ao fazer o build eu encontrei um pequeno alerta, não sei se está relacionado, mas vou reportar aqui.

![image](https://github.com/user-attachments/assets/5c6ed419-1fd7-45d2-b01f-1bb2e2532d2c)

Desde já agradeço pela confiança. Muito obrigado!!