### PR TITLE
Atualiza nomes de parâmetros de data, removendo _date

### DIFF
--- a/docs/en/source/contributing/scrapers.rst
+++ b/docs/en/source/contributing/scrapers.rst
@@ -78,7 +78,7 @@ If you want to collect data starting from another date, you can use the followin
 
 .. code-block:: sh
 
-    scrapy crawl my_city_spider -a start_date=2021-04-28
+    scrapy crawl my_city_spider -a start=2021-04-28
 
 
 The default value of `end_date` is today's date (the date when you are running your spider), so there's **no need** to define it in your spider class. This is set in the `BaseGazetteSpider`.
@@ -102,7 +102,7 @@ Here are some suggested checks:
 
 - Check if the downloaded files are valid;
 - Verify if you are collecting all available Official Gazettes;
-- If specifying the `start_date` and/or `end_date` arguments, ensure that you are not collecting more Official Gazettes than expected;
+- If specifying the `start` and/or `end` arguments, ensure that you are not collecting more Official Gazettes than expected;
 - Check if, when running the spider more than once, the results remain the same;
 - Ensure there are no execution errors (`log/ERROR` in spider statistics);
 

--- a/docs/pt_BR/source/contribuindo/raspadores.rst
+++ b/docs/pt_BR/source/contribuindo/raspadores.rst
@@ -567,8 +567,8 @@ e :attr:`~Gazette.date`, onde ficam os arquivos de diários oficiais baixados.
 
     scrapy crawl uf_nome_do_municipio [+ opções]
 
-- ``-a start_date=AAAA-MM-DD`` define novo valor para :attr:`~UFMunicipioSpider.start_date`
-- ``-a end_date=AAAA-MM-DD`` define novo valor para :attr:`~UFMunicipioSpider.end_date`
+- ``-a start=AAAA-MM-DD`` define novo valor para :attr:`~UFMunicipioSpider.start_date`
+- ``-a end=AAAA-MM-DD`` define novo valor para :attr:`~UFMunicipioSpider.end_date`
 - ``-s LOG_FILE=nome_arquivo.log`` salva as mensagens de *log* em arquivo de texto
 - ``-o nome_arquivo.csv`` salva a lista de diários oficiais e metadados coletados em arquivo tabular
 
@@ -585,7 +585,7 @@ Veja a data da edição mais recente no *site* publicador e execute a raspagem a
 
 .. code-block:: sh
 
-    scrapy crawl uf_nome_do_municipio -a start_date=AAAA-MM-DD
+    scrapy crawl uf_nome_do_municipio -a start=AAAA-MM-DD
   
 Coleta de intervalo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -594,7 +594,7 @@ execute a coleta desse intervalo arbitrário.
 
 .. code-block:: sh
 
-    scrapy crawl uf_nome_do_municipio -a start_date=AAAA-MM-DD -a end_date=AAAA-MM-DD
+    scrapy crawl uf_nome_do_municipio -a start=AAAA-MM-DD -a end=AAAA-MM-DD
 
 Coleta completa
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Em https://github.com/okfn-brasil/querido-diario/pull/1319, os nomes dos parâmetros de data passados para o raspador foram atualizados de forma a remover o sufixo `_date`.

De: `… -a start_date=2025-04-09 …`  para `… -a start=2025-04-09 …`

Esta PR atualiza os exemplos de chamada de raspador nos docs para refletirem a nova forma.