### PR TITLE
Fix API URL

### DIFF
--- a/docs/en/source/contributing/end-to-end-configuration.rst
+++ b/docs/en/source/contributing/end-to-end-configuration.rst
@@ -134,11 +134,11 @@ we'll do the following:
     .. code-block:: bash
 
       ./src/app/constants.ts
-      - export const API = 'https://queridodiario.ok.org.br/api';
+      - export const API = 'https://api.queridodiario.ok.org.br';
       + export const API = 'http://localhost:8080';
 
       ./src/app/services/utils/index.ts
-      - export const educationApi = 'https://backend-api.queridodiario.ok.org.br/api/';
+      - export const educationApi = 'https://backend-api.api.queridodiario.ok.org.br/';
 
       + export const educationApi = 'http://localhost:8000/api/';
 

--- a/docs/en/source/index.rst
+++ b/docs/en/source/index.rst
@@ -57,7 +57,7 @@ For more information, please see the `Terms of Use and Privacy Policy`_.
 
 .. REFERENCES
 .. _web platform: https://queridodiario.ok.org.br/
-.. _API: https://queridodiario.ok.org.br/api/docs
+.. _API: https://api.queridodiario.ok.org.br/docs
 .. _recurring funding campaign: https://www.catarse.me/queridodiario-okbr
 .. _directly to OKBR: https://ok.org.br/apoie/
 .. _teaching or research activities: https://ok.org.br/projetos/qd-universidades/

--- a/docs/en/source/understanding/architecture.rst
+++ b/docs/en/source/understanding/architecture.rst
@@ -85,7 +85,7 @@ facilitated. It has several endpoints through which different
 data can be requested from the official gazette databases and
 `CNPJs from the federal taxes service`_ (*Receita Federal do Brasil*, in Portuguese).
 
-- **Access**: https://queridodiario.ok.org.br/api/docs
+- **Access**: https://api.queridodiario.ok.org.br/docs
 - **Development**: `Python`_ using the `FastAPI`_ framework and automatic documentation
   with `Swagger`_.
 - **Production storage**: `PostgreSQL`_ for company metadata and `OpenSearch`_ for gazette

--- a/docs/en/source/using/public-api.rst
+++ b/docs/en/source/using/public-api.rst
@@ -7,7 +7,7 @@ The Public API is the gateway to Querido Diário. It offers several endpoints
 Learn how to use the API however you prefer, whether by watching a recording of a 
 usage workshop or through a textual tutorial, below.
 
-- **Documentation**: https://queridodiario.ok.org.br/api/docs
+- **Documentation**: https://api.queridodiario.ok.org.br/docs
 
 .. warning::
     **We do not impose any restrictions on API usage**. We hope for common sense 
@@ -67,7 +67,7 @@ with much more user-friendly navigation. Here, what is of interest, in fact, is 
 generated in the **Response URL** field. Our example search generates the following URL. 
 Try clicking in it and see what it offers:
 
-https://queridodiario.ok.org.br/api/gazettes?territory_ids=2700706&querystring=or%C3%A7amento&excerpt_size=500&number_of_excerpts=1&size=10
+https://api.queridodiario.ok.org.br/gazettes?territory_ids=2700706&querystring=or%C3%A7amento&excerpt_size=500&number_of_excerpts=1&size=10
 
 This URL is a permanent link to the search with this specific settings. It can be 
 added to scripts, such as data analysis code, to make automated use of Querido 
@@ -81,13 +81,13 @@ with different fields is an initial step that allows greater familiarity with
 how Querido Diário data is accessed. Continuing with the example above, the generated 
 URL explains the fields: 
 
-... the API was accessed: ``https://queridodiario.ok.org.br/api/``
+... the API was accessed: ``https://api.queridodiario.ok.org.br/``
 
-... in the "gazettes" endpoint: ``https://queridodiario.ok.org.br/api/gazettes?``
+... in the "gazettes" endpoint: ``https://api.queridodiario.ok.org.br/gazettes?``
 
-... searching for IBGE code territory "2700706": ``https://queridodiario.ok.org.br/api/gazettes?territory_ids=2700706``
+... searching for IBGE code territory "2700706": ``https://api.queridodiario.ok.org.br/gazettes?territory_ids=2700706``
 
-... using the search string "orçamento": ``https://queridodiario.ok.org.br/api/gazettes?territory_ids=2700706&querystring=orçamento``
+... using the search string "orçamento": ``https://api.queridodiario.ok.org.br/gazettes?territory_ids=2700706&querystring=orçamento``
 
 ... and so on.
 
@@ -99,10 +99,10 @@ of the fields, creating custom URLs at script runtime.
 An example, using the endpoint ``gazettes/``, highlighting the places where the 
 script would fill in the fields:
 
-``https://queridodiario.ok.org.br/api/gazettes?territory_ids={**ID**}querystring={**SEARCH KEYWORDS**}&excerpt_size={**VALUE**}&number_of_excerpts={**VALUE**}&size={**VALUE**}``
+``https://api.queridodiario.ok.org.br/gazettes?territory_ids={**ID**}querystring={**SEARCH KEYWORDS**}&excerpt_size={**VALUE**}&number_of_excerpts={**VALUE**}&size={**VALUE**}``
 
 .. REFERÊNCIAS
-.. _API docs page: https://queridodiario.ok.org.br/api/docs
+.. _API docs page: https://api.queridodiario.ok.org.br/docs
 .. _Python: https://www.python.org/
 .. _FastAPI: https://fastapi.tiangolo.com/
 .. _Swagger: https://swagger.io/

--- a/docs/pt_BR/source/contribuindo/configuracao-de-ponta-a-ponta.rst
+++ b/docs/pt_BR/source/contribuindo/configuracao-de-ponta-a-ponta.rst
@@ -138,11 +138,11 @@ Finalmente chegamos na outra ponta da arquitetura do QD, o `frontend`_! Aqui vam
     .. code-block:: bash
 
       ./src/app/constants.ts
-      - export const API = 'https://queridodiario.ok.org.br/api';
+      - export const API = 'https://api.queridodiario.ok.org.br';
       + export const API = 'http://localhost:8080';
 
       ./src/app/services/utils/index.ts
-      - export const educationApi = 'https://backend-api.queridodiario.ok.org.br/api/';
+      - export const educationApi = 'https://backend-api.api.queridodiario.ok.org.br/';
 
       + export const educationApi = 'http://localhost:8000/api/';
 

--- a/docs/pt_BR/source/entendendo/arquitetura.rst
+++ b/docs/pt_BR/source/entendendo/arquitetura.rst
@@ -79,7 +79,7 @@ A API Pública é a porta pela qual o acesso aos dados do projeto é facilitado.
 conta com diversos *endpoints* (pontos de acesso) pelos quais diferentes dados podem 
 ser solicitados às bases de dados de diários oficiais e de `CNPJs da Receita Federal`_. 
 
-- **Acesse**: https://queridodiario.ok.org.br/api/docs
+- **Acesse**: https://api.queridodiario.ok.org.br/docs
 - **Desenvolvimento**: `Python`_, biblioteca `FastAPI`_ e documentação automática com `Swagger`_.
 - **Armazenamento em produção**: `PostgreSQL`_ para metadados de empresas e `OpenSearch`_ para buscas em diários.
 - **Repositório de código**: https://github.com/okfn-brasil/querido-diario-api

--- a/docs/pt_BR/source/index.rst
+++ b/docs/pt_BR/source/index.rst
@@ -60,7 +60,7 @@ Para mais informações, consulte os `Termos de Uso e Política de Privacidade`_
 
 .. REFERÊNCIAS
 .. _plataforma web: https://queridodiario.ok.org.br/
-.. _API: https://queridodiario.ok.org.br/api/docs
+.. _API: https://api.queridodiario.ok.org.br/docs
 .. _campanha de financiamento recorrente: https://www.catarse.me/queridodiario-okbr
 .. _diretamente para a OKBR: https://ok.org.br/apoie/
 .. _atividades de ensino ou pesquisa: https://ok.org.br/projetos/qd-universidades/

--- a/docs/pt_BR/source/utilizando/api-publica.rst
+++ b/docs/pt_BR/source/utilizando/api-publica.rst
@@ -8,7 +8,7 @@ dados.
 Aprenda como utilizar a API conforme preferir, seja assistindo a gravação de uma 
 oficina de uso ou por meio de tutorial textual, logo abaixo.
 
-- **Acesse**: https://queridodiario.ok.org.br/api/docs
+- **Acesse**: https://api.queridodiario.ok.org.br/docs
 
 .. warning::
     **Não impomos nenhuma restrição para consumo da API**. Esperamos bom senso por parte 
@@ -68,7 +68,7 @@ com uma navegação muito mais amigável. Aqui, o que é de interesse, de fato, 
 gerada no campo **Response URL**. Nossa busca-exemplo gera a URL a seguir. Experimente 
 clicar e ver o que ela disponibiliza: 
 
-https://queridodiario.ok.org.br/api/gazettes?territory_ids=2700706&querystring=or%C3%A7amento&excerpt_size=500&number_of_excerpts=1&size=10
+https://api.queridodiario.ok.org.br/gazettes?territory_ids=2700706&querystring=or%C3%A7amento&excerpt_size=500&number_of_excerpts=1&size=10
 
 Esta URL é um *link* permanente para a pesquisa com configurações específicas. Ela 
 pode ser adicionada a *scripts*, como códigos de análise de dados, para fazer 
@@ -82,13 +82,13 @@ com diferentes campos é um passo inicial que possibilita maior familiaridade co
 como os dados do Querido Diário são acessados e percebendo os padrões de 
 preenchimento. Continuando com o exemplo acima, a URL gerada explicita os campos: 
 
-... a API foi acessada: ``https://queridodiario.ok.org.br/api/``
+... a API foi acessada: ``https://api.queridodiario.ok.org.br/``
 
-... no ponto de acesso "gazettes": ``https://queridodiario.ok.org.br/api/gazettes?``
+... no ponto de acesso "gazettes": ``https://api.queridodiario.ok.org.br/gazettes?``
 
-... buscando pelo território de código IBGE "2700706": ``https://queridodiario.ok.org.br/api/gazettes?territory_ids=2700706``
+... buscando pelo território de código IBGE "2700706": ``https://api.queridodiario.ok.org.br/gazettes?territory_ids=2700706``
 
-... usando a *string* de busca "orçamento": ``https://queridodiario.ok.org.br/api/gazettes?territory_ids=2700706&querystring=orçamento``
+... usando a *string* de busca "orçamento": ``https://api.queridodiario.ok.org.br/gazettes?territory_ids=2700706&querystring=orçamento``
 
 ... e assim por diante.
 
@@ -100,10 +100,10 @@ dos campos, criando URLs personalizadas em tempo de execução do *script*.
 Um exemplo, usando o *endpoint* ``gazettes/``, com destaque aos locais onde o 
 *script* preencheria os campos: 
 
-``https://queridodiario.ok.org.br/api/gazettes?territory_ids={**CÓDIGO IBGE**}querystring={**PALAVRAS-CHAVE**}&excerpt_size={**VALOR**}&number_of_excerpts={**VALOR**}&size={**VALOR**}``
+``https://api.queridodiario.ok.org.br/gazettes?territory_ids={**CÓDIGO IBGE**}querystring={**PALAVRAS-CHAVE**}&excerpt_size={**VALOR**}&number_of_excerpts={**VALOR**}&size={**VALOR**}``
 
 .. REFERÊNCIAS
-.. _página da API: https://queridodiario.ok.org.br/api/docs
+.. _página da API: https://api.queridodiario.ok.org.br/docs
 .. _Python: https://www.python.org/
 .. _FastAPI: https://fastapi.tiangolo.com/
 .. _Swagger: https://swagger.io/


### PR DESCRIPTION
Corrige a URl da API na documentação, usando a URL direto ao invés de um "path" com redirect.